### PR TITLE
set international date format for map popup

### DIFF
--- a/chatmap-ui/src/components/Map/utils.jsx
+++ b/chatmap-ui/src/components/Map/utils.jsx
@@ -10,13 +10,11 @@
  */
 export const formatDate = (time) => {
   const d = new Date(time);
-  return (
-    `${String(d.getDate()).padStart(2, '0')}/\
-${String(d.getMonth()+1).padStart(2, '0')}/\
-${String(d.getFullYear())}
-    ${String(d.getHours()).padStart(2, '0')}:\
-${String(d.getMinutes()).padStart(2, '0')}`
-  )
+
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(d);
 };
 
 /**


### PR DESCRIPTION
Uses `Intl.DateTimeFormat` to accomplish it.

Source: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat#style_shortcuts