### PR TITLE
fix db credentials

### DIFF
--- a/.github/workflows/build_deploy_master.yml
+++ b/.github/workflows/build_deploy_master.yml
@@ -98,6 +98,10 @@ jobs:
           CHATMAP_S3_BUCKET_NAME: ${{ vars.CHATMAP_S3_BUCKET_NAME }}
           CHATMAP_S3_ACCESS_KEY: ${{ vars.CHATMAP_S3_ACCESS_KEY }}
           CHATMAP_S3_SECRET_KEY: ${{ vars.CHATMAP_S3_SECRET_KEY }}
+          POSTGRES_DB: ${{ vars.PROD_POSTGRES_DB }}
+          POSTGRES_USER: ${{ vars.PROD_POSTGRES_USER }}
+          POSTGRES_PASSWORD: ${{ secrets.PROD_POSTGRES_PASSWORD }}
+          COOKIE_SECRET: ${{ secrets.PROD_COOKIE_SECRET }}
         run: |
           ssh $EC2_USER@$EC2_HOST << ENDSSH
             set -e
@@ -118,6 +122,10 @@ jobs:
             export CHATMAP_S3_ACCESS_KEY=$CHATMAP_S3_ACCESS_KEY
             export CHATMAP_S3_SECRET_KEY=$CHATMAP_S3_SECRET_KEY
             export CHATMAP_ENC_KEY=$CHATMAP_ENC_KEY
+            export POSTGRES_DB=$POSTGRES_DB
+            export POSTGRES_USER=$POSTGRES_USER
+            export POSTGRES_PASSWORD=$POSTGRES_PASSWORD
+            export COOKIE_SECRET=$COOKIE_SECRET
             # Initial setup if it doesn't exist
             if [ ! -d "\$APP_DIR" ]; then
               sudo mkdir -p \$APP_DIR

--- a/compose.yml
+++ b/compose.yml
@@ -25,8 +25,12 @@ services:
     ports:
       - "8000:8000"
     depends_on:
-      - chatmap-redis
-      - chatmap-db
+      chatmap-redis:
+        condition: service_started
+      chatmap-db:
+        condition: service_started
+      chatmap-api-migrate:
+        condition: service_completed_successfully
     environment:
       - REDIS_HOST=chatmap-redis
       - REDIS_PORT=6379
@@ -35,15 +39,15 @@ services:
       - CHATMAP_API_URL=${CHATMAP_API_URL:-http://localhost:8000}
       - CHATMAP_ENC_KEY=${CHATMAP_ENC_KEY:-0123456789ABCDEF0123456789ABCDEF}
       - CHATMAP_DB_HOST=${CHATMAP_DB_HOST:-chatmap-db}
-      - CHATMAP_DB=${POSTGRES_DB:-chatmap}
-      - CHATMAP_DB_USER=${POSTGRES_USER:-admin}
-      - CHATMAP_DB_PASSWORD=${POSTGRES_PASSWORD:-0123456789ABCDEF0123456789ABCDEF}
+      - CHATMAP_DB=${POSTGRES_DB}
+      - CHATMAP_DB_USER=${POSTGRES_USER}
+      - CHATMAP_DB_PASSWORD=${POSTGRES_PASSWORD}
       - CHATMAP_EXPIRING_MIN=${CHATMAP_EXPIRING_MIN:-30}
       - CHATMAP_CORS_ORIGINS=${CHATMAP_CORS_ORIGINS:-localhost,127.0.0.1}
       - CHATMAP_DISABLE_STREAM_CLEANUP=${CHATMAP_DISABLE_STREAM_CLEANUP:-false}
       - HANKO_API_URL=${HANKO_API_URL:-https://login.hotosm.org}
       - JWT_ISSUER=${JWT_ISSUER:-https://login.hotosm.org}
-      - COOKIE_SECRET=${COOKIE_SECRET:-dev-secret-key-min-32-bytes-long!}
+      - COOKIE_SECRET=${COOKIE_SECRET}
       - CHATMAP_S3_ENDPOINT_URL=${CHATMAP_S3_ENDPOINT_URL:-}
       - CHATMAP_S3_BUCKET_NAME=${CHATMAP_S3_BUCKET_NAME:-}
       - CHATMAP_S3_ACCESS_KEY=${CHATMAP_S3_ACCESS_KEY:-}
@@ -57,17 +61,17 @@ services:
 
   # Chatmap migrations
   chatmap-api-migrate:
-    build: ./chatmap-api/
+    image: ghcr.io/hotosm/chatmap-api:latest
     command: uv run alembic upgrade head
     depends_on:
       - chatmap-db
     networks:
       - chatmap_net
     environment:
-      - CHATMAP_DB_HOST=chatmap-db
-      - CHATMAP_DB=chatmap
-      - CHATMAP_DB_USER=admin
-      - CHATMAP_DB_PASSWORD=0123456789ABCDEF0123456789ABCDEF
+      - CHATMAP_DB_HOST=${CHATMAP_DB_HOST:-chatmap-db}
+      - CHATMAP_DB=${POSTGRES_DB}
+      - CHATMAP_DB_USER=${POSTGRES_USER}
+      - CHATMAP_DB_PASSWORD=${POSTGRES_PASSWORD}
 
   # Backend (IM connector)
   chatmap-go:
@@ -114,9 +118,9 @@ services:
     image: postgis/postgis:14-3.5-alpine
     restart: unless-stopped
     environment:
-      - POSTGRES_DB=${POSTGRES_DB:-chatmap}
-      - POSTGRES_USER=${POSTGRES_USER:-admin}
-      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-0123456789ABCDEF0123456789ABCDEF}
+      - POSTGRES_DB=${POSTGRES_DB}
+      - POSTGRES_USER=${POSTGRES_USER}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
     volumes:
       - data:/var/lib/postgresql/data
     ports:


### PR DESCRIPTION
## **IMPORTANT**

Before merging this PR, make sure the prod host has an `.env` file at `/home/<ec2-user>/chatmap/.env` (next to `compose.yml`) containing at least:

```
POSTGRES_DB=...
POSTGRES_USER=...
POSTGRES_PASSWORD=...
COOKIE_SECRET=...
```

`compose.yml` reads these through `${VAR}` interpolation, and there are no longer `:-` fallbacks for them, so a missing value makes the deploy fail at the migration step with `fe_sendauth: no password supplied`. The deploy's `git reset --hard origin/master` does not touch the untracked `.env`. See `.env.example` for the full list of supported keys.

## One-time DB version realignment (if the target env has drift)

Previously, we didn't wait for the result of the service that ran the migrations, so they failed silently. We've now added code to check whether the migrations ran successfully, but this revealed on the development branch that some tables had been created outside the migration flow, causing the table that tracks them to fall behind.

**Here's what I did to fix this problem in the development branch**

If the deploy fails at the migration step with `column "..." already exists` /
`relation "..." already exists`, the DB schema is ahead of `alembic_version`
(something was applied out-of-band). Temporarily add a `stamp` before the normal
migration run, in the deploy step l` and `up -d`:

```diff             # Pull and deploy
             docker compose -f com+            # ONE-TIME: DB has schema changes applied out-of-band while alembic_version
+            # is behind. Realign nding migrations can apply.+            # REMOVE this line after the deploy that fixes it.
+            docker compose -f comapi-migrate uv run alembic stamp<REV>
+            # Run migrations in tut/errors land in the CI log
+            docker compose -f compose.yml run --rm -T chatmap-api-migrate
             docker compose -f comtmap-api chatmap-nginx
chatmap-api-migrate chatmap-go --force-recreate
```

`<REV>` = the revision that matchet with
`docker compose -f compose.yml run --rm -T chatmap-api-migrate uv run alembic current`).
For dev it was `b7b2a3b424b8` (schersion was at `74a24da4d758`).

`alembic stamp <REV>` writes the r` **without** running
any migration DDL.

**Remove both added lines after a successful deploy** — otherwise the next deploy
stamps `alembic_version` backwardsreating an existing table.